### PR TITLE
feat: 支持 Bearer 认证方式以兼容更多 API 服务商

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -402,7 +402,10 @@ func (p *Proxy) handleProxy(w http.ResponseWriter, r *http.Request) {
 			q.Set("key", endpoint.APIKey)
 			proxyReq.URL.RawQuery = q.Encode()
 		} else {
+			// Set both x-api-key and Authorization headers for compatibility
+			// Some services use x-api-key (e.g., Anthropic Claude), others use Bearer token
 			proxyReq.Header.Set("x-api-key", endpoint.APIKey)
+			proxyReq.Header.Set("Authorization", "Bearer "+endpoint.APIKey)
 		}
 
 		proxyReq.Header.Set("Host", normalizedAPIUrl)


### PR DESCRIPTION
## 问题描述

目前在使用非 openai transformer 时，只支持 `x-api-key` header 进行认证。但是某些 API 服务提供商（如部分国内服务商）即使提供的是 Claude API，也要求使用标准的 `Authorization: Bearer <token>` header 进行认证。

这导致这些服务无法正常工作，通常会返回 405 Method Not Allowed 或 401 Unauthorized 错误。

## 解决方案

在 claude transformer（else 分支）的认证处理中，同时设置 `x-api-key` 和 `Authorization: Bearer` 两种认证头：

```go
// Set both x-api-key and Authorization headers for compatibility
// Some services use x-api-key (e.g., Anthropic Claude), others use Bearer token
proxyReq.Header.Set("x-api-key", endpoint.APIKey)
proxyReq.Header.Set("Authorization", "Bearer "+endpoint.APIKey)
```

这种方式：
- ✅ 保持向后兼容（原有服务继续使用 x-api-key）
- ✅ 支持新的服务（使用 Bearer token 的服务商）
- ✅ HTTP 协议允许多个认证头；服务端会忽略不需要的认证方式
- ✅ 不影响 openai 和 gemini transformer 的现有逻辑

## 测试验证

已在本地环境测试：
- ✅ 使用 `x-api-key` 的服务（q.quuvv.cn, pro.privnode.com）继续正常工作
- ✅ 需要 `Authorization: Bearer` 的服务（88code.org 等）现在也能正常工作
- ✅ 没有任何破坏性变更

## 相关 Issue

Closes #4
