### PR TITLE
feat: 添加当前端点显示和手动切换功能

### DIFF
--- a/app.go
+++ b/app.go
@@ -749,3 +749,20 @@ func (a *App) TestEndpoint(index int) string {
 	logger.Info("Test successful for %s", endpoint.Name)
 	return string(data)
 }
+
+// GetCurrentEndpoint returns the current active endpoint name
+func (a *App) GetCurrentEndpoint() string {
+	if a.proxy == nil {
+		return ""
+	}
+	return a.proxy.GetCurrentEndpointName()
+}
+
+// SwitchToEndpoint manually switches to a specific endpoint by name
+func (a *App) SwitchToEndpoint(endpointName string) error {
+	if a.proxy == nil {
+		return fmt.Errorf("proxy not initialized")
+	}
+
+	return a.proxy.SetCurrentEndpoint(endpointName)
+}

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -25,7 +25,10 @@ export default {
         delete: 'Delete',
         noEndpoints: 'No endpoints configured. Click "Add Endpoint" to get started.',
         copy: 'Copy',
-        copied: 'Copied'
+        copied: 'Copied',
+        current: 'Current',
+        switchTo: 'Switch',
+        switchFailed: 'Switch Failed'
     },
     modal: {
         addEndpoint: 'Add Endpoint',

--- a/frontend/src/i18n/zh-CN.js
+++ b/frontend/src/i18n/zh-CN.js
@@ -25,7 +25,10 @@ export default {
         delete: '删除',
         noEndpoints: '未配置端点。点击"添加端点"开始使用。',
         copy: '复制',
-        copied: '已复制'
+        copied: '已复制',
+        current: '当前使用',
+        switchTo: '切换',
+        switchFailed: '切换失败'
     },
     modal: {
         addEndpoint: '添加端点',

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -538,3 +538,41 @@ body {
 .copy-btn:active {
     transform: scale(0.95);
 }
+
+/* Current badge */
+.current-badge {
+    background: #4CAF50;
+    color: white;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: normal;
+    margin-left: 8px;
+    vertical-align: middle;
+    display: inline-block;
+}
+
+/* Switch button */
+.btn-switch {
+    background: #667eea;
+    color: white;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: normal;
+    margin-left: 8px;
+    border: none;
+    cursor: pointer;
+    transition: all 0.2s;
+    vertical-align: middle;
+    display: inline-block;
+}
+
+.btn-switch:hover {
+    background: #5568d3;
+}
+
+.btn-switch:disabled {
+    background: #BDBDBD;
+    cursor: not-allowed;
+}

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -7,6 +7,8 @@ export function ClearLogs():Promise<void>;
 
 export function GetConfig():Promise<string>;
 
+export function GetCurrentEndpoint():Promise<string>;
+
 export function GetLanguage():Promise<string>;
 
 export function GetLogLevel():Promise<number>;
@@ -34,6 +36,8 @@ export function SetLanguage(arg1:string):Promise<void>;
 export function SetLogLevel(arg1:number):Promise<void>;
 
 export function ShowWindow():Promise<void>;
+
+export function SwitchToEndpoint(arg1:string):Promise<void>;
 
 export function TestEndpoint(arg1:number):Promise<string>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -14,6 +14,10 @@ export function GetConfig() {
   return window['go']['main']['App']['GetConfig']();
 }
 
+export function GetCurrentEndpoint() {
+  return window['go']['main']['App']['GetCurrentEndpoint']();
+}
+
 export function GetLanguage() {
   return window['go']['main']['App']['GetLanguage']();
 }
@@ -68,6 +72,10 @@ export function SetLogLevel(arg1) {
 
 export function ShowWindow() {
   return window['go']['main']['App']['ShowWindow']();
+}
+
+export function SwitchToEndpoint(arg1) {
+  return window['go']['main']['App']['SwitchToEndpoint'](arg1);
 }
 
 export function TestEndpoint(arg1) {


### PR DESCRIPTION
  ## 功能描述

  在端点列表中显示当前正在使用的端点，并支持手动切换到其他已启用的端点。

  ## 实现内容

  ### 后端改动（~42 行）

  **internal/proxy/proxy.go**：
  - 新增 `GetCurrentEndpointName()` 方法 - 获取当前端点名称（线程安全）
  - 新增 `SetCurrentEndpoint(name)` 方法 - 手动切换到指定端点（线程安全）

  **app.go**：
  - 新增 `GetCurrentEndpoint()` API - 返回当前端点名称
  - 新增 `SwitchToEndpoint(name)` API - 调用 proxy 切换端点

  ### 前端改动（~51 行）

  **frontend/src/modules/endpoints.js**：
  - 将 `renderEndpoints()` 改为异步函数，调用后端获取当前端点
  - 为当前端点添加绿色"当前使用"标签
  - 为其他已启用端点添加"切换"按钮及点击事件
  - 利用现有的 5 秒定时器自动刷新，无需额外轮询

  **frontend/src/i18n/*.js**：
  - 添加国际化文本：`current`、`switchTo`、`switchFailed`

  **frontend/src/style.css**：
  - 添加 `.current-badge` 样式（绿色标签）
  - 添加 `.btn-switch` 样式（紫色按钮，与主题一致）

  ## 技术细节

  - **线程安全**：使用现有的 `sync.RWMutex` 保证并发安全
  - **请求隔离**：切换端点不会影响正在进行的请求
  - **日志记录**：手动切换会记录日志：`[MANUAL SWITCH] 端点A → 端点B`
  - **UI 自动更新**：复用现有的 5 秒刷新机制，零额外性能开销

  ## 测试情况

  ✅ 本地编译通过（macOS arm64）  
  ✅ 手动切换端点功能正常  
  ✅ 当前端点标识显示正确  
  ✅ 后台自动切换时 UI 自动更新（5 秒内）  
  ✅ 不影响现有功能和自动轮换机制  
  ✅ 基于最新 v1.1.0 版本

  ## 补充说明

  - 完全向后兼容，不影响任何现有功能
  - 代码改动极小（约 93 行新代码）
  - 所有改动都是新增，没有修改现有逻辑
  - 支持中英文界面
 
 ## 关联
  Closes #13