### PR TITLE
feat: add -port CLI flag to lock port configuration

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"flag"
 	"net/http"
 	"os"
 	"os/signal"
@@ -18,6 +19,9 @@ import (
 )
 
 func main() {
+	// Parse command line flags
+	portFlag := flag.Int("port", 0, "Force specific port (locked, cannot be changed via API)")
+	flag.Parse()
 	dataDir := resolveDataDir()
 	if err := os.MkdirAll(dataDir, 0755); err != nil {
 		logger.Error("Failed to create data dir %s: %v", dataDir, err)
@@ -40,6 +44,13 @@ func main() {
 	if err != nil {
 		logger.Error("Unable to load configuration: %v", err)
 		os.Exit(1)
+	}
+
+	// Handle -port CLI flag (overrides config and locks port)
+	if *portFlag > 0 {
+		cfg.Port = *portFlag
+		cfg.LockPort()
+		logger.Info("Port locked to %d via CLI flag", *portFlag)
 	}
 
 	if cfg.BasicAuthEnabled && cfg.BasicAuthPassword == "" {

--- a/cmd/server/webui/api/config.go
+++ b/cmd/server/webui/api/config.go
@@ -146,9 +146,15 @@ func (h *Handler) handleConfigPort(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		WriteSuccess(w, map[string]interface{}{
-			"port": h.config.GetPort(),
+			"port":       h.config.GetPort(),
+			"portLocked": h.config.IsPortLocked(),
 		})
 	case http.MethodPut:
+		if h.config.IsPortLocked() {
+			WriteError(w, http.StatusForbidden, "Port is locked by CLI flag and cannot be changed")
+			return
+		}
+
 		var req struct {
 			Port int `json:"port"`
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -160,6 +160,7 @@ type ProxyConfig struct {
 // Config represents the application configuration
 type Config struct {
 	Port                  int             `json:"port"`
+	PortLocked            bool            `json:"-"` // CLI forced port, cannot be changed via API
 	BasicAuthEnabled     bool            `json:"basicAuthEnabled"`
 	BasicAuthUsername     string          `json:"basicAuthUsername"`
 	BasicAuthPassword    string          `json:"basicAuthPassword"`
@@ -318,10 +319,28 @@ func (c *Config) UpdateEndpoints(endpoints []Endpoint) {
 }
 
 // UpdatePort updates the port (thread-safe)
+// If PortLocked is true, the port cannot be changed
 func (c *Config) UpdatePort(port int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.PortLocked {
+		return
+	}
 	c.Port = port
+}
+
+// LockPort locks the port so it cannot be changed via API
+func (c *Config) LockPort() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.PortLocked = true
+}
+
+// IsPortLocked returns true if the port is locked
+func (c *Config) IsPortLocked() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.PortLocked
 }
 
 // UpdateLogLevel updates the log level (thread-safe)


### PR DESCRIPTION
    - 新增 -port 命令行参数强制指定端口
    - CLI 指定的端口会被锁定，无法通过 API 修改
    - GET /api/config/port 返回 portLocked 状态
    - PUT /api/config/port 在锁定时返回 403 禁止访问
