### PR TITLE
在 openai2 转换器中添加 developer → system 的 role 映射

### DIFF
--- a/internal/transformer/convert/openai_openai2.go
+++ b/internal/transformer/convert/openai_openai2.go
@@ -108,6 +108,9 @@ func OpenAI2ReqToOpenAI(openai2Req []byte, model string) ([]byte, error) {
 					pendingToolCalls = nil
 				}
 				role, _ := itemMap["role"].(string)
+				if role == "developer" {
+					role = "system"
+				}
 				text := extractOpenAI2Text(itemMap["content"])
 				messages = append(messages, transformer.OpenAIMessage{Role: role, Content: text})
 


### PR DESCRIPTION
OpenAI Responses API 支持 developer 角色（用于 o1 等模型），但 Chat Completions API 不支持该角色。当客户端通过 Responses 接口发送 role: "developer" 的消息时，原代码原样传递给 Chat API 后端导致报错。

修改内容：在 OpenAI2ReqToOpenAI 函数的 "message" 分支中，将 "developer" 自动映射为 "system"。